### PR TITLE
Add Google Keep label script

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,25 @@ longer-term interests ...
     Electoral Systems since 1997.
     
  * What causes the preceding monospace style?  (Likely the leading spaces)
+
+## Google Keep Integration
+
+This repository now includes a small Python script, `google_keep_tags.py`, which
+can add labels to notes in Google Keep. It relies on the open source
+[gkeepapi](https://github.com/kiwiz/gkeepapi) library.
+
+### Quick start
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set your Google account credentials using environment variables:
+   ```bash
+   export KEEP_EMAIL="you@example.com"
+   export KEEP_PASSWORD="your-app-password"
+   ```
+3. Apply a label to a note:
+   ```bash
+   python google_keep_tags.py --note NOTE_ID --label MyLabel
+   ```
+The script will create the label if necessary and attach it to the note.

--- a/google_keep_tags.py
+++ b/google_keep_tags.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Simple script to apply labels in Google Keep using gkeepapi.
+
+Usage:
+ 1. Install dependencies:
+      pip install gkeepapi
+ 2. Set environment variables KEEP_EMAIL and KEEP_PASSWORD with your
+    Google account credentials. Using an app password is recommended.
+ 3. Run the script:
+      python google_keep_tags.py --note NOTE_ID --label LABEL
+
+This script logs in to Google Keep, finds or creates the given label,
+then applies it to the specified note.
+"""
+
+import os
+import argparse
+import gkeepapi
+
+
+def login():
+    email = os.environ.get("KEEP_EMAIL")
+    password = os.environ.get("KEEP_PASSWORD")
+    if not email or not password:
+        raise ValueError("KEEP_EMAIL and KEEP_PASSWORD must be set")
+    keep = gkeepapi.Keep()
+    success = keep.login(email, password)
+    if not success:
+        raise RuntimeError("Login to Google Keep failed")
+    return keep
+
+
+def add_label(keep, note_id: str, label_name: str) -> None:
+    note = keep.get(note_id)
+    if note is None:
+        raise ValueError(f"Note {note_id} not found")
+    label = keep.findLabel(label_name)
+    if label is None:
+        label = keep.createLabel(label_name)
+    note.labels.add(label)
+    keep.sync()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Add or modify Google Keep labels")
+    parser.add_argument("--note", required=True, help="ID of the note to modify")
+    parser.add_argument("--label", required=True, help="Label to add to the note")
+    args = parser.parse_args()
+
+    keep = login()
+    add_label(keep, args.note, args.label)
+    print(f"Label '{args.label}' added to note {args.note}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+gkeepapi


### PR DESCRIPTION
## Summary
- add a Python script to apply labels to Google Keep notes
- document the script in the README
- include `gkeepapi` dependency in `requirements.txt`

## Testing
- `python3 -m py_compile google_keep_tags.py`


------
https://chatgpt.com/codex/tasks/task_e_68840fb7028083208b9c8b730e3c3707

## Summary by Sourcery

Add a Python script to tag Google Keep notes with labels and update documentation accordingly

New Features:
- Introduce google_keep_tags.py script to log in to Google Keep and apply or create labels on specified notes

Documentation:
- Document Google Keep tagging script and provide usage instructions in README